### PR TITLE
Test the result of "setup.py upload" for errors.

### DIFF
--- a/tc_build.sh
+++ b/tc_build.sh
@@ -1,5 +1,4 @@
-#! /bin/bash
-set -e
+#! /bin/bash -e
 
 LIB_NAME=pylcp
 VIRTUALENV_DIR=../.virtualenvs/$LIB_NAME
@@ -36,5 +35,7 @@ if [ $TEST_RC -ne 0 ]; then
 fi
 
 # Build distribution
-python setup.py sdist $UPLOAD
-
+SETUP_ERRORS=$(mktemp /tmp/tc-build-errors.XXXXXX)
+trap "rm -f $SETUP_ERRORS" 0 2 3 15
+python setup.py sdist $UPLOAD 2> >(tee $SETUP_ERRORS >&2)
+grep --ignore-case --invert-match "Upload failed" $SETUP_ERRORS

--- a/tc_build.sh
+++ b/tc_build.sh
@@ -20,7 +20,7 @@ fi
 rm -rf $VIRTUALENV_DIR
 virtualenv --no-site-packages $VIRTUALENV_DIR
 source $VIRTUALENV_DIR/bin/activate
-pip install pip==1.5.4
+pip install --upgrade pip==1.5.4
 pip install -r requirements-dev.txt
 
 # Static analysis
@@ -38,4 +38,6 @@ fi
 SETUP_ERRORS=$(mktemp /tmp/tc-build-errors.XXXXXX)
 trap "rm -f $SETUP_ERRORS" 0 2 3 15
 python setup.py sdist $UPLOAD 2> >(tee $SETUP_ERRORS >&2)
-grep --ignore-case --invert-match "Upload failed" $SETUP_ERRORS
+if grep --quiet "Upload failed" $SETUP_ERRORS; then
+  exit 1
+fi


### PR DESCRIPTION
Setup.py returns zero if the upload fails due to a 400
from the PyPI server. This can happen, for example, when
attempting to upload with a version number that has already
been uploaded.

Having the test in this script avoids the problem of forgetting
to add it in the CI server's config.