### PR TITLE
DPPTSBGTC-2838 Use setup(extras_require...) instead of requirements.txt.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,7 @@ python:
   - "3.4"
   - "3.5"
 install:
-  - "pip install -r requirements.txt"
-  - "pip install -r requirements-dev.txt"
+  - "pip install .[dev]"
   - "pip install coveralls"
 script: flake8 && nosetests
 after_success:

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,4 @@
 include version_number.txt
-include requirements.txt
-include requirements-dev.txt
 include LICENSE.md
 include README.md
 

--- a/docs/source/dev.rst
+++ b/docs/source/dev.rst
@@ -19,10 +19,9 @@ documentation updates.
 Development Dependencies
 ------------------------
 
-To run tests on PyLCP, install the development requirements from requirements-dev.txt
-which also install the run-time requirement::
+To run tests on PyLCP, install the development requirements::
 
-    pip install -r requirements-dev.txt
+    pip install .[dev]
 
 Testing
 -------
@@ -39,15 +38,15 @@ virtualenv active::
 
 or if you prefer pip::
 
-    pip install -e path/to/pylcp/source
+    pip install -e .
 
 Documentation
 -------------
 
 To build build the documentation, install Sphinx and related requirements::
 
+    pip install .[docs]
     cd docs
-    pip install -r requirements.txt
     make html
 
 To view locally built documentation, open the file docs/build/html/index.html in

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,9 +1,0 @@
--r requirements.txt
-coverage==3.7.1
-flake8==2.4.1
-mccabe==0.3
-mock==1.0.1
-nose==1.3.7
-pep8==1.6.2
-pyflakes==0.9.1
-teamcity-messages==1.14

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,0 @@
-future>=0.4.13,<1.0
-requests>=2.2.1,<3.0
-simplejson>=3.6.4

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,10 @@
 # Necessary to supress on error in Python 2.7.3 at the completion of
 # python setup.py test.
 # See http://bugs.python.org/issue15881#msg170215
-import multiprocessing        # NOQA
+import multiprocessing  # NOQA
 
 import distutils.command.clean
 import os
-import pkg_resources
 import setuptools
 import subprocess
 
@@ -28,35 +27,41 @@ def read_first_line(file_name):
         return f.readline().strip()
 
 
-def read_requirements(file_path):
-    return [
-        i.strip()
-        for i in pkg_resources.resource_string(__name__, file_path).split()
-        if i.strip()[0:1] != '#' and i.strip()[0:2] != '--' and len(i.strip()) > 0
-    ]
+REQUIREMENTS = [
+    'future>=0.4.13,<1.0',
+    'requests>=2.2.1,<3.0',
+    'simplejson>=3.6.4'
+]
+DEV_REQUIREMENTS = [
+    'coverage==3.7.1',
+    'flake8==2.5.4',
+    'mccabe==0.3',
+    'mock==1.0.1',
+    'nose==1.3.7',
+    'pep8==1.7.0',
+    'pyflakes==1.0.0',
+    'teamcity-messages==1.14'
+]
 
-
-REQUIREMENTS = read_requirements('requirements.txt')
-TEST_REQUIREMENTS = read_requirements('requirements-dev.txt')
-
+DOCS_REQUIREMENTS = ['sphinx']
 
 setuptools.setup(name='PyLCP',
                  version=read_first_line('version_number.txt'),
                  description="Python client library for Points Loyalty Commerce Platform.",
                  long_description=read_file('README.md'),
                  classifiers=[
-                      'Development Status :: 5 - Production/Stable',
-                      'Environment :: Web Environment',
-                      'Intended Audience :: Developers',
-                      'License :: OSI Approved :: BSD License',
-                      'Natural Language :: English',
-                      'Operating System :: POSIX :: Linux',
-                      'Programming Language :: Python',
-                      'Programming Language :: Python :: 2.7',
-                      'Programming Language :: Python :: 3.3',
-                      'Programming Language :: Python :: 3.4',
-                      'Topic :: Internet :: WWW/HTTP :: Dynamic Content',
-                      'Topic :: Software Development :: Libraries :: Python Modules'
+                     'Development Status :: 5 - Production/Stable',
+                     'Environment :: Web Environment',
+                     'Intended Audience :: Developers',
+                     'License :: OSI Approved :: BSD License',
+                     'Natural Language :: English',
+                     'Operating System :: POSIX :: Linux',
+                     'Programming Language :: Python',
+                     'Programming Language :: Python :: 2.7',
+                     'Programming Language :: Python :: 3.3',
+                     'Programming Language :: Python :: 3.4',
+                     'Topic :: Internet :: WWW/HTTP :: Dynamic Content',
+                     'Topic :: Software Development :: Libraries :: Python Modules'
                  ],
                  keywords='LCP REST',
                  author='Points International',
@@ -71,7 +76,11 @@ setuptools.setup(name='PyLCP',
                  # -*- Entry points: -*-
                  """,
                  test_suite='nose.collector',
-                 tests_require=TEST_REQUIREMENTS,
+                 tests_require=DEV_REQUIREMENTS,
+                 extras_require={
+                     'dev': DEV_REQUIREMENTS,
+                     'docs': DEV_REQUIREMENTS + DOCS_REQUIREMENTS
+                 },
                  cmdclass={
                      'clean': Clean
                  },


### PR DESCRIPTION
See [DPPTSBGTC-2838](https://jira.points.com/browse/DPPTSBGTC-2838)

``setup.py#read_requirements()`` fails while parsing the first line of "requirements-dev.txt", because it does not correctly handle the content "-r requirements.txt".

This PR implements the second suggested fix in the story description:
> Alternatively, instead of fixing ``read_requirements()``, we can eschew the requirements.txt files entirely by leveraging [extras_require](https://pythonhosted.org/setuptools/setuptools.html#declaring-extras-optional-features-with-their-own-dependencies).

This is the other proposed solution is:
```bash
$ python -c "\
> def read_requirements(file_path):
>     lines = pkg_resources.resource_string(__name__, file_path)
>     return clean_requirements(lines)
> 
> def clean_requirements(lines):
>     lines = (line.strip() for line in lines)
>     lines = (line for line in lines if line)
>     lines = (line.split()[0].strip() for line in lines)
>     return [line for line in lines if line[0] not in ('-', '#')]
> 
> if __name__ == '__main__':
>     sample = (
>         '-r requirements.txt',
>         '--index-url',
>         ' good ',
>         'great #bad',
>         '# bad',
>         '',
>         ' ',
>     )
>     assert clean_requirements(sample) == ['good', 'great']
>     print('OK')"
OK```