### PR TITLE
Fix TeamCity Build.

### DIFF
--- a/tc_build.sh
+++ b/tc_build.sh
@@ -22,6 +22,7 @@ virtualenv --no-site-packages $VIRTUALENV_DIR
 source $VIRTUALENV_DIR/bin/activate
 pip install --upgrade pip
 pip install .[dev]
+pip install requests[security]
 
 # Static analysis
 flake8 pylcp tests setup.py


### PR DESCRIPTION
The 2.7.3 version of python in TeamCity requires additional packages to stop the InsecurePlatformWarning and hence a failed build.
see http://stackoverflow.com/questions/29099404/ssl-insecureplatform-error-when-using-requests-package