### PR TITLE
Refactors LCPResource to behave more consistently

### DIFF
--- a/pylcp/crud/base.py
+++ b/pylcp/crud/base.py
@@ -25,33 +25,25 @@ class LCPResource(object):
     are correctly initialized.
     """
     def __init__(self, response=None):
-        self._json = None
         self.response = response
-        self._url = None
-
-        if response is not None:
-            if response.status_code != NO_CONTENT:
-                self._json = response.json()
-                try:
-                    self._url = self._self_link()
-                except KeyError:
-                    pass
-            if 'location' in response.headers:
-                self._url = response.headers['location']
 
     @property
     def url(self):
-        return self._url
+        if self.response and 'location' in self.response.headers:
+            return self.response.headers['location']
+
+        # Traverse the dictionary returning None if a key isn't found during traversal
+        return reduce(lambda d, key: d.get(key, None) if isinstance(d, dict) else None,
+                      ['links', 'self', 'href'], self.json)
 
     @property
     def json(self):
-        return self.response.json()
-
-    def _self_link(self):
-        return self._json['links']['self']['href']
+        if self.response:
+            return self.response.json()
+        return {}
 
     def __getitem__(self, key):
-        return self._json[key]
+        return self.json[key]
 
 
 class LCPCrud(object):

--- a/tests/crud/test_base.py
+++ b/tests/crud/test_base.py
@@ -59,6 +59,15 @@ class TestLCPResource(object):
         json_copy['links'] = 'foo'
         tools.assert_equal('some_url', lcp_obj['links']['self']['href'])
 
+    @tools.raises(KeyError)
+    def test_getitem_with_no_response_raises_keyerror(self):
+        lcp_obj = crud.LCPResource()
+        foo = lcp_obj['foo']
+
+    def test_json_instantiated_with_no_response(self):
+        lcp_obj = crud.LCPResource()
+        tools.assert_dict_equal({}, lcp_obj.json)
+
 
 class TestLCPCRUD(object):
     def setup(self):


### PR DESCRIPTION
Refactors LCPResource to behave more consistently based on a default
ctor parameter of None for response.
The json property will return an empty dict rather than throwing an
exception if no response is set.  As a result, getitem will throw a key
error under the same conditions.  url behaves the same, logic refactored
without try/except and moved from ctor to property.