### PR TITLE
Removes CRUDError which masks the requests library HTTPError

### DIFF
--- a/pylcp/crud/base.py
+++ b/pylcp/crud/base.py
@@ -13,9 +13,6 @@ try:
 except ImportError:
     from httplib import NO_CONTENT
 
-import requests
-import simplejson as json
-
 
 class LCPResource(object):
     """Base class for loyalty domain objects for LCP services
@@ -88,55 +85,10 @@ class LCPCrud(object):
     def _resource_from_http(self, method, path, payload=None, params=None):
         response = None
 
-        try:
-            response = self._http_method(method)(path, data=payload, params=params)
-            response.raise_for_status()
-        except requests.RequestException:
-            raise CRUDError(path, method, response, **{'request_payload': payload, 'request_parameters': params})
+        response = self._http_method(method)(path, data=payload, params=params)
+        response.raise_for_status()
+
         return self.resource_class(response)
 
     def _http_method(self, method):
         return getattr(self.http_client, method.lower())
-
-
-class CRUDError(Exception):
-    def __init__(self, url, method, response, **request_kwargs):
-        formatted_request = self._format_optional_args(request_kwargs)
-
-        super(CRUDError, self).__init__(
-            "{status_code} returned.\n"
-            "Method: {method}\n"
-            "Correlation ID: {cid}\n"
-            "URL: {url}\n"
-            "{formatted_request}"
-            "Response: {response}".format(
-                url=url,
-                method=method,
-                status_code=response.status_code,
-                cid=response.headers.get('pts-lcp-cid', 'none'),
-                formatted_request=formatted_request,
-                response=response.text,
-            ))
-
-    def _format_optional_args(self, request_kwargs):
-        formatted_request = ''
-        for key in list(request_kwargs.keys()):
-            value = request_kwargs[key]
-            label = self._format_label(key)
-
-            if isinstance(value, dict):
-                formatted_value = self._format_dictionary(label, value)
-            else:
-                formatted_value = u'{}: "{}"\n'.format(label, value)
-            formatted_request += formatted_value
-
-        return formatted_request
-
-    def _format_label(self, text):
-        return text.replace('_', ' ').capitalize()
-
-    def _format_dictionary(self, label, dict_to_format):
-        formatted_dictionary = ''
-        if dict_to_format is not None:
-            formatted_dictionary = u'{}: {}\n'.format(label, json.dumps(dict_to_format, indent=2, sort_keys=True))
-        return formatted_dictionary

--- a/tests/crud/test_base.py
+++ b/tests/crud/test_base.py
@@ -2,7 +2,6 @@ from future import standard_library
 standard_library.install_aliases()  # NOQA
 
 from builtins import object
-import decimal
 try:
     from http.client import NO_CONTENT
     from http.client import NOT_FOUND
@@ -74,10 +73,10 @@ class TestLCPCRUD(object):
         tools.assert_equal(1, self.mock_client.post.call_count)
         test_base.assert_lcp_resource(mocked_response, response)
 
-    def test_request_failures_raises_crud_error(self):
+    def test_request_failures_raises_http_error(self):
         mocked_response = test_base.mock_response(status_code=NOT_FOUND)
         self.mock_client.post.return_value = mocked_response
-        with tools.assert_raises(crud.CRUDError):
+        with tools.assert_raises(requests.HTTPError):
             self.lcp_crud.create(test_base.SAMPLE_URL, {})
 
     def test_read(self):
@@ -120,55 +119,3 @@ class TestLCPCRUD(object):
         response = self.lcp_crud.search(test_base.SAMPLE_URL)
         tools.assert_equal(1, self.mock_client.get.call_count)
         test_base.assert_lcp_resource(mocked_response, response)
-
-
-class TestCrudErrors(object):
-    def test_create_exception_with_no_request_payload_returns_exception_with_empty_request(self):
-        response_mock = mock.Mock(spec=requests.Response)
-        response_mock.headers = {}
-        response_mock.text = "text"
-        response_mock.status_code = NOT_FOUND
-
-        crud_error = crud.CRUDError('/path/', 'POST', response_mock)
-
-        tools.assert_equal('404 returned.\nMethod: POST\n'
-                           'Correlation ID: none\nURL: /path/\nResponse: text',
-                           str(crud_error))
-
-    def test_create_exception_with_request_payload_returns_exception_with_request_payload(self):
-        response_mock = mock.Mock(spec=requests.Response)
-        response_mock.headers = {}
-        response_mock.text = "text"
-        response_mock.status_code = NOT_FOUND
-
-        crud_error = crud.CRUDError('/path/', 'POST', response_mock, **{'request_payload': 'some_payload'})
-
-        tools.assert_equal('404 returned.\nMethod: POST\n'
-                           'Correlation ID: none\nURL: /path/\nRequest payload: "some_payload"\nResponse: text',
-                           str(crud_error))
-
-    def test_create_exception_with_request_payload_containing_decimal_data_returns_exception_with_request(self):
-        response_mock = mock.Mock(spec=requests.Response)
-        response_mock.headers = {}
-        response_mock.text = "text"
-        response_mock.status_code = NOT_FOUND
-        request_payload = {'decimal': decimal.Decimal('3.15')}
-
-        crud_error = crud.CRUDError('/path/', 'POST', response_mock, **{'request_payload': request_payload})
-
-        tools.assert_equal('404 returned.\nMethod: POST\n'
-                           'Correlation ID: none\nURL: /path/\nRequest payload: {\n  "decimal": 3.15\n}\n'
-                           'Response: text',
-                           str(crud_error))
-
-    def test_create_exception_with_request_parameters_returns_exception_with_parameters(self):
-        response_mock = mock.Mock(spec=requests.Response)
-        response_mock.headers = {}
-        response_mock.text = "text"
-        response_mock.status_code = NOT_FOUND
-
-        crud_error = crud.CRUDError('/path/', 'POST', response_mock, **{'request_parameters': {'a': 'b'}})
-
-        tools.assert_equal('404 returned.\nMethod: POST\n'
-                           'Correlation ID: none\nURL: /path/\nRequest parameters: {\n  "a": "b"\n}\nResponse: text',
-                           str(crud_error))


### PR DESCRIPTION
Removes CRUDError which masks the requests library HTTPError and its
properties, like the request and response objects which contain
information such as the status code.

CRUDError seemed to serve no purpose other than to output an error
message with very specific information.  However, all of that info
(mostly contained in the request and response objects) is logged by the
APILogger.

Given that, it makes sense to pass the requests HTTPError up
to the client rather than breaking the exception chain with CRUDError.
The client can enable logging to output the same info that CRUDError
delivered.

Note that while this eliminates CRUDError, and exception (HTTPError) is still
raised in the same place and in the same way.